### PR TITLE
Update Dockerfile and dependencies for ROS2 transition to jazzy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ ARG PROJECT_MAINTAINER
 # pick an icon from: https://fontawesome.com/v4.7.0/icons/
 ARG PROJECT_ICON="cube"
 ARG PROJECT_FORMAT_VERSION
-# ROS2
-ARG ROS2_DISTRO=rolling
 
 # ==================================================>
 # ==> Do not change the code below this line
@@ -40,7 +38,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 # - ROS2
-ARG ROS2_DISTRO
+ARG ROS2_DISTRO=jazzy
 
 # ROS2 info
 ENV ROS2_DISTRO="${ROS2_DISTRO}" \

--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -7,8 +7,14 @@
 # ament-cmake-googletest
 
 # ROS2 packages
-ros-rolling-ros-base
-ros-rolling-rclpy
+ros-jazzy-ros-base
+ros-jazzy-rclpy
 
 # TODO: cv-bridge is not very efficient, replace it with turbo-jpeg
-ros-rolling-cv-bridge
+ros-jazzy-cv-bridge
+
+# ros-camera build dependencies
+ros-jazzy-camera-info-manager
+libcamera0.2
+pkg-config
+libcamera-dev


### PR DESCRIPTION
## Goal

Update and build the dt-ros2-commons Docker image using ROS 2 Jazzy, ensuring full compatibility with the existing project structure and dependencies.

## Success Criteria

The build is considered successful when the standard ROS 2 talker and listener example can run in separate containers, communicating as described in the repository’s README. This verifies that the image supports inter-container ROS 2 communication and that all required dependencies are properly installed.

## Acceptance Steps

1. Build the updated dt-ros2-commons image with ROS 2 Jazzy.

1. Start a container running the talker node as per README.md.

1. Start another container running the listener node as per README.md.

1. Confirm that the listener receives and logs messages from the talker without errors.

