### PR TITLE
Adopt Zenoh as middleware and fix setup.cfg keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,3 +142,5 @@ LABEL \
 # <== Do not change the code above this line
 # <================================================== \
 
+# Use Zenoh as RMW implementation
+ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp

--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -18,3 +18,5 @@ ros-jazzy-camera-info-manager
 libcamera0.2
 pkg-config
 libcamera-dev
+
+ros-jazzy-rmw-zenoh-cpp

--- a/packages/my_package/setup.cfg
+++ b/packages/my_package/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/my_package
+script_dir=$base/lib/my_package
 [install]
-install-scripts=$base/lib/my_package
+install_scripts=$base/lib/my_package


### PR DESCRIPTION
Integrate Zenoh as the middleware implementation and correct the `script_dir` and `install_scripts` keys in `setup.cfg`.