### PR TITLE
fix: pin empy to 3.3.4 for ROS 2 rosidl compatibility

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -8,6 +8,9 @@ Flask-Cors==4.0.0
 # this is for DTROS and buff_size input
 humanfriendly==10.0
 
+# empy 4.x breaks ROS 2 rosidl message generation (em.TransientParseError); pin to the rosidl-compatible release
+empy==3.3.4
+
 # colcon build system
 colcon-common-extensions<=0.3.0
 


### PR DESCRIPTION
empy 4.x changed its API and breaks rosidl message generation (em.TransientParseError) during colcon builds. Pin to 3.3.4, the last release compatible with the ROS 2 rosidl code generators.

DTSW-7910