### PR TITLE
DTSW-8095-Add-optical_flow-package-to-dt-ros2-core

### DIFF
--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -12,6 +12,8 @@ ros-jazzy-rclpy
 
 # TODO: cv-bridge is not very efficient, replace it with turbo-jpeg
 ros-jazzy-cv-bridge
+ros-jazzy-compressed-image-transport
+python3-opencv
 
 # ros-camera build dependencies
 ros-jazzy-camera-info-manager

--- a/packages/opencv_apps/CMakeLists.txt
+++ b/packages/opencv_apps/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5)
+project(opencv_apps)
+
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(msg_files
+  msg/Point2D.msg
+  msg/Flow.msg
+  msg/FlowArrayStamped.msg
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES std_msgs
+)
+
+install(PROGRAMS
+  scripts/fback_flow
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/packages/opencv_apps/msg/Flow.msg
+++ b/packages/opencv_apps/msg/Flow.msg
@@ -1,0 +1,2 @@
+opencv_apps/Point2D point
+opencv_apps/Point2D velocity

--- a/packages/opencv_apps/msg/FlowArrayStamped.msg
+++ b/packages/opencv_apps/msg/FlowArrayStamped.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+opencv_apps/Flow[] flow
+bool[] status

--- a/packages/opencv_apps/msg/Point2D.msg
+++ b/packages/opencv_apps/msg/Point2D.msg
@@ -1,0 +1,2 @@
+float64 x
+float64 y

--- a/packages/opencv_apps/package.xml
+++ b/packages/opencv_apps/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>opencv_apps</name>
+  <version>0.0.1</version>
+  <description>Minimal ROS 2 compatibility package for the opencv_apps flow interfaces used by Duckietown.</description>
+
+  <maintainer email="info@duckietown.com">Duckietown</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/packages/opencv_apps/scripts/fback_flow
+++ b/packages/opencv_apps/scripts/fback_flow
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+from typing import Optional
+
+import cv2
+import numpy as np
+import rclpy
+from cv_bridge import CvBridge, CvBridgeError
+from opencv_apps.msg import Flow, FlowArrayStamped, Point2D
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import Image
+
+
+class FBackFlowNode(Node):
+    def __init__(self) -> None:
+        super().__init__("fback_flow")
+
+        self.declare_parameter("queue_size", 3)
+        self.declare_parameter("debug_view", False)
+        self.declare_parameter("use_camera_info", False)
+        self.declare_parameter("step", 16)
+        self.declare_parameter("pyr_scale", 0.5)
+        self.declare_parameter("levels", 3)
+        self.declare_parameter("winsize", 15)
+        self.declare_parameter("iterations", 3)
+        self.declare_parameter("poly_n", 5)
+        self.declare_parameter("poly_sigma", 1.2)
+
+        self._bridge = CvBridge()
+        self._previous_gray: Optional[np.ndarray] = None
+        self._previous_stamp: Optional[tuple[int, int]] = None
+
+        self._image_publisher = self.create_publisher(Image, "~/image", 1)
+        self._flow_publisher = self.create_publisher(FlowArrayStamped, "~/flows", 1)
+        self.create_subscription(Image, "image", self.cb_image, qos_profile_sensor_data)
+
+    def cb_image(self, msg: Image) -> None:
+        try:
+            frame = self._bridge.imgmsg_to_cv2(msg, desired_encoding="bgr8")
+        except CvBridgeError as error:
+            self.get_logger().warning(f"Failed to convert image: {error}")
+            return
+
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY) if frame.ndim == 3 else frame.copy()
+
+        stamp = (msg.header.stamp.sec, msg.header.stamp.nanosec)
+        if self._previous_stamp is not None and stamp < self._previous_stamp:
+            self.get_logger().warning("Detected time jump backwards. Clearing optical-flow cache.")
+            self._previous_gray = None
+
+        flows_msg = FlowArrayStamped()
+        flows_msg.header = msg.header
+
+        debug_image = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
+        if self._previous_gray is not None:
+            flow = cv2.calcOpticalFlowFarneback(
+                self._previous_gray,
+                gray,
+                None,
+                float(self.get_parameter("pyr_scale").value),
+                int(self.get_parameter("levels").value),
+                int(self.get_parameter("winsize").value),
+                int(self.get_parameter("iterations").value),
+                int(self.get_parameter("poly_n").value),
+                float(self.get_parameter("poly_sigma").value),
+                0,
+            )
+
+            step = int(self.get_parameter("step").value)
+            color = (0, 255, 0)
+            for y_coord in range(0, debug_image.shape[0], step):
+                for x_coord in range(0, debug_image.shape[1], step):
+                    delta_x = float(flow[y_coord, x_coord, 0])
+                    delta_y = float(flow[y_coord, x_coord, 1])
+                    start_point = (int(x_coord), int(y_coord))
+                    end_point = (int(round(x_coord + delta_x)), int(round(y_coord + delta_y)))
+
+                    cv2.line(debug_image, start_point, end_point, color)
+                    cv2.circle(debug_image, start_point, 2, color, -1)
+
+                    flow_msg = Flow()
+                    point_msg = Point2D()
+                    velocity_msg = Point2D()
+                    point_msg.x = float(x_coord)
+                    point_msg.y = float(y_coord)
+                    velocity_msg.x = delta_x
+                    velocity_msg.y = delta_y
+                    flow_msg.point = point_msg
+                    flow_msg.velocity = velocity_msg
+                    flows_msg.status.append(True)
+                    flows_msg.flow.append(flow_msg)
+
+        self._previous_gray = gray
+        self._previous_stamp = stamp
+
+        debug_msg = self._bridge.cv2_to_imgmsg(debug_image, encoding="bgr8")
+        debug_msg.header = msg.header
+        self._image_publisher.publish(debug_msg)
+        self._flow_publisher.publish(flows_msg)
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = FBackFlowNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new minimal ROS 2 compatibility package, `opencv_apps`, to provide flow interfaces and a Farneback optical flow node used by Duckietown. It adds the necessary ROS message definitions, build configuration, and a Python node for calculating and publishing optical flow data. Additionally, dependencies are updated to support these features.

**New ROS 2 package and flow interface support:**

* Created the `opencv_apps` package with ROS 2 compatible `package.xml` and `CMakeLists.txt`, including message generation and installation of the optical flow script. [[1]](diffhunk://#diff-0894d4f467e7ce798580d827c7fe4d2effbf2c3facd500c4565ed5eeac531bb2R1-R26) [[2]](diffhunk://#diff-9f4938415054634cfbdcc973bd89d2292fa0ea653914ace1c351680660911ff2R1-R27)
* Added new message definitions: `Point2D`, `Flow`, and `FlowArrayStamped` to represent optical flow data. [[1]](diffhunk://#diff-06a027fa3959d895563ed44e889d552ef3315efec9562d6d836a9ac30285970eR1-R2) [[2]](diffhunk://#diff-3c627ddcc02d0ce81c3523b455655f6a558dd5fa16d85cfc58655bc3789e67cdR1-R2) [[3]](diffhunk://#diff-ea80eaed6cfe78242f7f1b4057866290a44ad765e0360e03a6cc3412feffeaa2R1-R3)

**Optical flow node implementation:**

* Implemented the `fback_flow` Python node, which subscribes to images, computes dense Farneback optical flow, and publishes both flow vectors and a debug image.

**Dependency updates:**

* Updated `dependencies-apt.txt` to include `ros-jazzy-compressed-image-transport` and `python3-opencv`, ensuring required dependencies for image processing and transport are available.